### PR TITLE
Makefile: fix linking to real-time shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OPTIMIZE=-O2
 CFLAGS=-Wall -Werror -Wshadow -Wextra $(OPTIMIZE) -std=gnu99
-LDFLAGS=
+LDFLAGS=-lrt
 OBJECTS=$(patsubst %.c,%.o,$(wildcard *.c))
 
 link_sim: $(OBJECTS)


### PR DESCRIPTION
This fix the linking error of "undefined reference to
`clock_gettime' for 'nix which doesn't link this library by default
such as Debian 7 "Wheezy".
