### PR TITLE
link_sim: fix broken port parsing

### DIFF
--- a/link_sim.c
+++ b/link_sim.c
@@ -464,8 +464,8 @@ int main(int argc, char **argv)
 		switch (opt) {
 #define _READINT_CAP(x, y, lim) case x: y = atoi(optarg) % lim; break;
 #define _READINT(x, y) _READINT_CAP(x, y, INT_MAX)
-			_READINT_CAP('p', port, (1 << 16) - 1)
-			_READINT_CAP('P', forward_port, (1 << 16) - 1)
+			_READINT_CAP('p', port, (1 << 16))
+			_READINT_CAP('P', forward_port, (1 << 16))
 			_READINT('d', delay)
 			_READINT('j', jitter)
 			_READINT_CAP('e', err_rate, 101)


### PR DESCRIPTION
Commits be0eae2 and d35d441 broke the port parsing. It removes one
unity from the given one in arg.

![dman](https://cloud.githubusercontent.com/assets/1769603/10649131/a2becd3e-7842-11e5-9221-ee334cae2679.png)
